### PR TITLE
chore: draft of collateFilesForReview function

### DIFF
--- a/src/collateFilesForReview.js
+++ b/src/collateFilesForReview.js
@@ -1,0 +1,55 @@
+/* eslint-disable filenames/match-regex */
+const { exec } = require('child_process')
+const fs = require('fs')
+const readline = require('readline')
+
+// Function to execute a shell command and return a promise
+const execPromise = command => {
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`exec error: ${error}`))
+        return
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+export const collateFilesForReview = async () => {
+  try {
+    // 1. Get the files that have had lines changed in the PR
+    await execPromise(`git diff HEAD^1 --numstat --output=diff_stats_raw.txt`)
+
+    // 2. Remove files that have less than 3 added lines
+    await execPromise(
+      `awk '$1 >= 3 { print $3 }' diff_stats_raw.txt > diff_stats_only_paths_with_gte_3_lines_added.txt`
+    )
+
+    // 3. Use file paths to get the total number of lines in each file
+    const readInterface = readline.createInterface({
+      input: fs.createReadStream(
+        'diff_stats_only_paths_with_gte_3_lines_added.txt'
+      ),
+      output: process.stdout,
+      console: false
+    })
+
+    let fileData = ''
+
+    // 4. Remove files that are longer than 200 lines
+    // This will create a file that has the file paths the files that should be reviewed by the AI
+    for await (const filePath of readInterface) {
+      const stdout = await execPromise(
+        `cd .. && wc -l ${filePath} | awk '{if ($1 < 200) print $2}' >> src/diff_stats_only_paths_with_gte_3_lines_added_and_lt_200_lines.txt`
+      )
+      console.log(`path: ${filePath}`)
+      console.log(`stdout: ${stdout}`)
+      fileData += stdout
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+collateFilesForReview()


### PR DESCRIPTION
## Scope: 

Implement a function that:
1. Gets the diff from Git
2. Filters out: files that have <= 3 line changes
3. Filters out files that have more than 200 line of code.

## Notes
Currently the code outputs a new txt file after each step in the code. Perhaps this could be cleaned up and objects/arrays could be used instead. But this is kinda tricky because of the use of terminal commands like `wc -l` which returns the total number of lines for a particular file path.

## Known issue:
- needs to be run twice for everything to work. I think the await isn't being respected or something